### PR TITLE
Commented Mage:Log lines to prevent system.log from flooding

### DIFF
--- a/app/code/community/Segment/Analytics/Model/Front/Controller.php
+++ b/app/code/community/Segment/Analytics/Model/Front/Controller.php
@@ -20,7 +20,7 @@ class Segment_Analytics_Model_Front_Controller
         
     public function addDeferredAction($action, $action_data=array())
     {
-        Mage::Log("Adding Deferred Action $action");
+        #Mage::Log("Adding Deferred Action $action");
         
         $o_action = new stdClass;
         $o_action->action = $action;
@@ -40,7 +40,7 @@ class Segment_Analytics_Model_Front_Controller
         Mage::getSingleton('segment_analytics/session')
         ->setDeferredActions(array())
         ->setDeferredActionsData(array());
-        Mage::Log("Cleared Deferred Action");
+        #Mage::Log("Cleared Deferred Action");
         return $this;
     }
     

--- a/app/code/community/Segment/Analytics/Model/Observer.php
+++ b/app/code/community/Segment/Analytics/Model/Observer.php
@@ -41,7 +41,7 @@ class Segment_Analytics_Model_Observer
                 $container->append($block);
             }
         }
-        Mage::Log("Finished addContainerBlocks");
+        #Mage::Log("Finished addContainerBlocks");
     }
 
     /**
@@ -262,7 +262,7 @@ class Segment_Analytics_Model_Observer
             return;
         }
 
-        Mage::Log($observer->getTransport()->getHtml(), Zend_Log::INFO, 'segment.log');
+        #Mage::Log($observer->getTransport()->getHtml(), Zend_Log::INFO, 'segment.log');
     }
     
     public function addClickedShareJavascript($observer)


### PR DESCRIPTION
After simply going through the order process I have a lot of lines in my `var/log/system.log` coming from the Segment Analytics module. I commented out these lines as they provide no relevant information while all operations run normally. These lines would be necessary for developing, testing and debugging only.

I also commented out writing the HTML output to the `segment.log` in `Segment_Analytics_Model_Observer::logBlockHtml()` for the same reasons and during this simple test run the 
`segment.log` was already over 60Kb in file size.

![selection_045](https://cloud.githubusercontent.com/assets/2794908/6105249/5f9bd30e-b055-11e4-8deb-43af402a74ba.png)

Please check and accept my changes, @sperand-io / @ianstormtaylor 