### PR TITLE
removing code that accidentally overwrites casting of Magento product

### DIFF
--- a/app/code/community/Segment/Analytics/Model/Controller/Orderplaced.php
+++ b/app/code/community/Segment/Analytics/Model/Controller/Orderplaced.php
@@ -9,9 +9,11 @@ class Segment_Analytics_Model_Controller_Orderplaced extends Segment_Analytics_M
         ->info($params['increment_id']);
 
         $params['total']            = (float) $info['grand_total'];
+        $params['revenue']          = (float) $info['subtotal'];
         $params['status']           = $info['status'];
         $params['shipping']         = (float) $info['shipping_amount'];
         $params['tax']              = (float) $info['tax_amount'];
+        $params['discount']         = (-1 * (float) $info['discount_amount']);
         $params['products']         = array();
         foreach($info['items'] as $item)
         {

--- a/app/code/community/Segment/Analytics/Model/Controller/Orderplaced.php
+++ b/app/code/community/Segment/Analytics/Model/Controller/Orderplaced.php
@@ -4,35 +4,31 @@ class Segment_Analytics_Model_Controller_Orderplaced extends Segment_Analytics_M
     public function getBlock($block)
     {
         $params = $block->getParams();
-        
+
         $info    = Mage::getModel('sales/order_api')
         ->info($params['increment_id']);
-        
+
         $params['total']            = (float) $info['grand_total'];
-        $params['status']           = $info['status'];        
+        $params['status']           = $info['status'];
         $params['shipping']         = (float) $info['shipping_amount'];
         $params['tax']              = (float) $info['tax_amount'];
         $params['products']         = array();
         foreach($info['items'] as $item)
         {
-            $tmp = array();      
+            $tmp = array();
             $tmp['sku']           = $item['sku'];
-            $tmp['name']          = $item['name'];;
+            $tmp['name']          = $item['name'];
             $tmp['price']         = (float) $item['price'];
             $tmp['quantity']      = (float) $item['qty_ordered'];
-            $tmp['product_id']    = (int) $item['product_id'];            
+            $tmp['product_id']    = (int) $item['product_id'];
 
-            //in case we ever add the boolean order items
-            $tmp = Mage::helper('segment_analytics')->getDataCastAsBooleans($item);
             $params['products'][] = $tmp;
         }
 
-        //too much information?
-        //$block->setParams($info);
-        
+
         //the serialized information
         $block->setParams($params);
-        
+
         return $block;
     }
 }


### PR DESCRIPTION
In the model there is code that converts an of Magento products into a hash that is compatible with Segment's API. However, after the information is casted it was being overwritten back to its original state. I also removed the boolean casting method because the code is manually casted. 

I'm also adding functionality to record discounts and revenue.