### PR TITLE
Prevent Fatal Error when Flat Catalog is enabled

### DIFF
--- a/app/code/community/Segment/Analytics/Helper/Data.php
+++ b/app/code/community/Segment/Analytics/Helper/Data.php
@@ -97,7 +97,7 @@ class Segment_Analytics_Helper_Data extends Mage_Core_Helper_Abstract
         //if passed id, load the product
         if(!is_array($product))
         {
-            $product = Mage::getModel('catalog/product_api')->info($product);
+            $product = Mage::getModel('catalog/product_api')->info($product, Mage::app()->getStore());
         }
 
         //calculate revenue, if present


### PR DESCRIPTION
Hi, we recently had a client install this extension who encountered an error that crashed their site.  Fortunately they were able to debug and fix the error.  Their description of the problem and solution is below, and this pull request makes the update that ultimately solved the problem for them.

Note that they're currently using version 1.1 of the plugin, so some of the line numbers may not match up exactly.
### Issue description

Module Segment_Analytics has observer:

In Segment_Analytics_Model_Observer::Segment_Analytics_Model_Observer on line 32 we have

```
$blocks = $front->getBlocks();
```

One of blocks is block for viewed products(segment_analytics/viewedproduct.phtml).
It calls Segment_Analytics_Model_Controller_Viewedproduct::getBlock($block)

On line 9 it calls

```
 $product   = Mage::helper('segment_analytics')
        ->getNormalizedProductInformation($params['id']);   
```

In Segment_Analytics_Helper_Data::getNormalizedProductInformation($product) we load product using API model(line 90):

```
$product = Mage::getModel('catalog/product_api')->info($product);
```

At this point we do not have store set. When store is not set, then Magento tries to get if from session or if value not set - it will set admin store ID:

```
Mage_Catalog_Model_Api_Resource::_getStoreId($store = null)
 protected function _getStoreId($store = null)
    {
        if (is_null($store)) {
            $store = ($this->_getSession()->hasData($this->_storeIdSessionField)
                        ? $this->_getSession()->getData($this->_storeIdSessionField) : 0);
        }

        try {
            $storeId = Mage::app()->getStore($store)->getId();
        } catch (Mage_Core_Model_Store_Exception $e) {
            $this->_fault('store_not_exists');
        }

        return $storeId;
    }
```

So, here product loaded with store ID=0. Which is admin store. Also there is core observer Mage_CatalogInventory_Model_Observer::addInventoryData($observer) that adds this product with store ID=0 to inventory model.

Later when page rendered, Magento displays block "product_type_data_extra"(in template catalog/product/view/type/grouped.phtml):

```
<?php echo $this->getChildHtml('product_type_data_extra') ?>
```

One of child blocks is a block with type Mage_CatalogInventory_Block_Stockqty_Default

Later this block calls Mage_Catalog_Model_Product_Type_Grouped::getProductsToPurchaseByReqGroups($product = null)

In this function Magento tries to take all associated products for our Grouped products. Also it tries to load attributes. When attributes loaded, there is check if enabled flat catalog for products. Since the product has store ID = 0, this check returns wrong result and we receive following error:

```
 Fatal error: Call to undefined method Mage_Catalog_Model_Resource_Product_Flat::loadAllAttributes() in /Library/WebServer/Documents/northshorecare/app/code/core/Mage/Eav/Model/Entity/Collection/Abstract.php on line 435
Call Stack
#   Time    Memory  Function    Location
1   0.0029  263912  {main}( )   .../index.php:0
2   0.0740  716216  Mage::run( ???, ???, ??? )  .../index.php:89
3   0.0782  1655272 Mage_Core_Model_App->run( ??? ) .../Mage.php:684
4   0.1800  7986512 Mage_Core_Controller_Varien_Front->dispatch( )  .../App.php:354
5   0.2265  10048696    Mage_Core_Controller_Varien_Router_Standard->match( ??? )   .../Front.php:172
6   0.2316  10414248    Mage_Core_Controller_Varien_Action->dispatch( ??? ) .../Standard.php:254
7   0.3486  14574416    Mage_Catalog_ProductController->viewAction( )   .../Action.php:418
8   0.3498  14622552    Mage_Catalog_Helper_Product_View->prepareAndRender( ???, ???, ??? ) .../ProductController.php:132
9   3.9581  41345328    Mage_Core_Controller_Varien_Action->renderLayout( ??? ) .../View.php:147
10  8.4984  42129336    Mage_Core_Model_Layout->getOutput( )    .../Action.php:390
11  8.4984  42129808    Mage_Core_Block_Abstract->toHtml( ) .../Layout.php:555
12  8.4992  42132968    Mage_Core_Block_Template->_toHtml( )    .../Abstract.php:919
13  8.4992  42133080    Mage_Core_Block_Template->renderView( ) .../Template.php:286
14  8.5002  42135024    Mage_Core_Block_Template->fetchView( ??? )  .../Template.php:272
15  8.5011  42173128    include( '/Library/WebServer/Documents/northshorecare/app/design/frontend/enterprise/northshore/template/page/1column.phtml' )  .../Template.php:241
16  9.2639  50107344    Mage_Core_Block_Abstract->getChildHtml( ???, ???, ??? ) .../1column.phtml:53
17  9.2639  50107440    Mage_Core_Block_Abstract->_getChildHtml( ???, ??? ) .../Abstract.php:581
18  9.2639  50107440    Mage_Core_Block_Abstract->toHtml( ) .../Abstract.php:637
19  9.2643  50107656    Mage_Core_Block_Text_List->_toHtml( )   .../Abstract.php:919
20  9.2643  50107792    Mage_Core_Block_Abstract->toHtml( ) .../List.php:43
21  9.2647  50108008    Mage_Core_Block_Template->_toHtml( )    .../Abstract.php:919
22  9.2647  50108008    Mage_Core_Block_Template->renderView( ) .../Template.php:286
23  9.2652  50108144    Mage_Core_Block_Template->fetchView( ??? )  .../Template.php:272
24  9.2660  50254736    include( '/Library/WebServer/Documents/northshorecare/app/design/frontend/enterprise/northshore/template/catalog/product/view.phtml' )  .../Template.php:241
25  17.7422 54680800    Mage_Core_Block_Abstract->getChildHtml( ???, ???, ??? ) .../view.phtml:164
26  17.7422 54680896    Mage_Core_Block_Abstract->_getChildHtml( ???, ??? ) .../Abstract.php:581
27  17.7422 54681320    Mage_Core_Block_Abstract->toHtml( ) .../Abstract.php:637
28  17.7427 54682128    Mage_Core_Block_Template->_toHtml( )    .../Abstract.php:919
29  17.7427 54682240    Mage_Core_Block_Template->renderView( ) .../Template.php:286
30  17.7434 54682952    Mage_Core_Block_Template->fetchView( ??? )  .../Template.php:272
31  17.7441 54737928    include( '/Library/WebServer/Documents/northshorecare/app/design/frontend/enterprise/northshore/template/catalog/product/view/type/grouped.phtml' ) .../Template.php:241
32  22.4265 54831912    Mage_Core_Block_Abstract->getChildHtml( ???, ???, ??? ) .../grouped.phtml:39
33  22.4265 54832120    Mage_Core_Block_Abstract->_getChildHtml( ???, ??? ) .../Abstract.php:581
34  22.4265 54832184    Mage_Core_Block_Abstract->toHtml( ) .../Abstract.php:637
35  22.4274 54832400    Mage_Core_Block_Text_List->_toHtml( )   .../Abstract.php:919
36  22.4275 54832968    Mage_Core_Block_Abstract->toHtml( ) .../List.php:43
37  22.4287 54834008    Mage_CatalogInventory_Block_Stockqty_Default->_toHtml( )    .../Abstract.php:919
38  22.4287 54834072    Mage_CatalogInventory_Block_Stockqty_Abstract->isMsgVisible( )  .../Default.php:44
39  22.4287 54834184    Mage_CatalogInventory_Block_Stockqty_Abstract->getStockQty( )   .../Abstract.php:97
40  22.4288 54834576    Mage_CatalogInventory_Model_Stock_Item->getStockQty( )  .../Abstract.php:59
41  22.4290 54835088    Mage_Catalog_Model_Product_Type_Grouped->getProductsToPurchaseByReqGroups( ??? )    .../Item.php:846
42  53.0895 54835088    Mage_Catalog_Model_Product_Type_Grouped->getAssociatedProducts( ??? )   .../Grouped.php:349
43  63.4032 54853592    Mage_Catalog_Model_Resource_Product_Collection->addAttributeToSelect( ???, ??? )    .../Grouped.php:134
44  91.7680 54854080    Mage_Eav_Model_Entity_Collection_Abstract->addAttributeToSelect( ???, ??? ) .../Collection.php:517
```
### Proposed Fix

issue can be solved if we add param store in method that loads product by API model in the helper:

Change line 90 in app/code/community/Segment/Analytics/Helper/Data.php:

FROM:

`$product = Mage::getModel('catalog/product_api')->info($product);`

TO:

`$product = Mage::getModel('catalog/product_api')->info($product, Mage::app()->getStore());`
